### PR TITLE
do not compare location, correctly compare location across Isolates.

### DIFF
--- a/lib/src/date_time.dart
+++ b/lib/src/date_time.dart
@@ -372,9 +372,7 @@ class TZDateTime implements DateTime {
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        other is TZDateTime &&
-            _native.isAtSameMomentAs(other._native) &&
-            location == other.location;
+        other is TZDateTime && _native.isAtSameMomentAs(other._native);
   }
 
   /// Returns true if [this] occurs before [other].

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -221,6 +221,14 @@ class Location {
 
   @override
   String toString() => name;
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) || other is Location && name == other.name;
+  }
 }
 
 /// A [TimeZone] represents a single time zone such as CEST or CET.

--- a/test/comparison_test.dart
+++ b/test/comparison_test.dart
@@ -1,18 +1,40 @@
 @TestOn('vm')
 library;
 
+import 'dart:isolate';
+
 import 'package:test/test.dart';
 import 'package:timezone/standalone.dart';
 
 Future<void> main() async {
   await initializeTimeZone();
-  group('Test equality and inequality', () {
+  group('Equality and inequality of Timezones', () {
     test('Test that == checks for the same moment in time, not location', () {
-      final location1 = getLocation('Europe/London');
-      final location2 = getLocation('America/Detroit');
+      final location1 = getLocation('Europe/London'); // UTC+0 on 2021-01-01
+      final location2 = getLocation('America/Detroit'); // UTC-5 on 2021-01-01
       final time1 = TZDateTime(location1, 2021, 1, 1, 5, 0);
       final time2 = TZDateTime(location2, 2021, 1, 1, 0, 0);
       expect(time1, time2);
+    });
+
+    test('Test that != checks for the same moment in time, not location', () {
+      final location1 = getLocation('Europe/London');
+      final location2 = getLocation('America/Detroit');
+      final time1 = TZDateTime(location1, 2021, 1, 1, 20, 0);
+      final time2 = TZDateTime(location2, 2021, 1, 1, 0, 0);
+      expect(time1 != time2, isTrue);
+    });
+  });
+
+  group('Equality of Locations', () {
+    test('Test that Locations initialized on different threads are equal',
+        () async {
+      final location1 = getLocation('Europe/London');
+      final location2 = await Isolate.run(() async {
+        await initializeTimeZone();
+        return getLocation('Europe/London');
+      });
+      expect(location1, location2);
     });
   });
 }

--- a/test/comparison_test.dart
+++ b/test/comparison_test.dart
@@ -1,0 +1,18 @@
+@TestOn('vm')
+library;
+
+import 'package:test/test.dart';
+import 'package:timezone/standalone.dart';
+
+Future<void> main() async {
+  await initializeTimeZone();
+  group('Test equality and inequality', () {
+    test('Test that == checks for the same moment in time, not location', () {
+      final location1 = getLocation('Europe/London');
+      final location2 = getLocation('America/Detroit');
+      final time1 = TZDateTime(location1, 2021, 1, 1, 5, 0);
+      final time2 = TZDateTime(location2, 2021, 1, 1, 0, 0);
+      expect(time1, time2);
+    });
+  });
+}


### PR DESCRIPTION
We want == of TZDateTimes to mean `isSameMomentAs` for continuity with `Datetime` and sanity of thread/class ID things.